### PR TITLE
Threading instead of multiprocessing. Other performance tricks. Fixes hang issue

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import pygame
 
 from buffalo import utils

--- a/chunk.py
+++ b/chunk.py
@@ -21,7 +21,7 @@ class Chunk:
 
     LOADED_SURFACES = dict()
 
-    def __init__(self, x, y, from_other_process=False):
+    def __init__(self, x, y, from_other_thread=False):
         """
         This is the Chunk constructor.
         It creates a Chunk at the coordinates (<x>, <y>).
@@ -51,21 +51,26 @@ class Chunk:
             self.defs = Biome.GenerateBiomeDefs()
             self.toFile()
         self.fromFile(x,y)
-        if not from_other_process:
+        if not from_other_thread:
             self.create_and_render_surface()
 
     def create_and_render_surface(self):
-        self.label = Label(
-            (5,5),
-            str((self.pos[0], self.pos[1])),
-            font="default36",
-            color=(0,0,0,255)
-        )
+#        self.label = Label(
+#            (5,5),
+#            str((self.pos[0], self.pos[1])),
+#            font="default36",
+#            color=(0,0,0,255)
+#        )
         self.surface = utils.empty_surface(
             (Chunk.TILE_SIZE * Chunk.CHUNK_WIDTH, Chunk.TILE_SIZE * Chunk.CHUNK_HEIGHT)
         )
         self.render()
 
+    def create_surface(self):
+        self.surface = utils.empty_surface(
+            (Chunk.TILE_SIZE * Chunk.CHUNK_WIDTH, Chunk.TILE_SIZE * Chunk.CHUNK_HEIGHT)
+        )
+        
     @staticmethod
     def loadSurfaceForId(_id):
         if _id in Chunk.LOADED_SURFACES.keys():
@@ -144,20 +149,20 @@ class Chunk:
             for x, col in enumerate(row):
                 if col in self.defs.keys():
                     #Image/Texture Based Rendering
-                    self.surface.blit(
-                        Chunk.loadSurfaceForId(col),
-                        (x * Chunk.TILE_SIZE, y * Chunk.TILE_SIZE)
-                    )
+                    #self.surface.blit(
+                    #    Chunk.loadSurfaceForId(col),
+                    #    (x * Chunk.TILE_SIZE, y * Chunk.TILE_SIZE)
+                    #)
 
                     #Color Based Rendering
-                    #self.surface.fill(
-                    #    self.defs[col],
-                    #    pygame.Rect(
-                    #        (x * Chunk.TILE_SIZE, y * Chunk.TILE_SIZE),
-                    #        (Chunk.TILE_SIZE, Chunk.TILE_SIZE),
-                    #    )
-                    #)
-        self.label.blit(self.surface)
+                    self.surface.fill(
+                        self.defs[col],
+                        pygame.Rect(
+                            (x * Chunk.TILE_SIZE, y * Chunk.TILE_SIZE),
+                            (Chunk.TILE_SIZE, Chunk.TILE_SIZE),
+                        )
+                    )
+#        self.label.blit(self.surface)
 
     def blit(self, dest, pos):
         dest.blit( self.surface, pos )

--- a/editMapTestScene.py
+++ b/editMapTestScene.py
@@ -1,10 +1,6 @@
 import os
 import os.path
 import sys
-from multiprocessing import Queue
-
-import numpy
-import numpy.random
 
 import pygame
 
@@ -64,8 +60,6 @@ class CameraController:
 
 class EditMapTestScene(Scene):
     def on_escape(self):
-        MapManager.soft_load_reader_queue = Queue()
-        MapManager.soft_load_reader_queue.put("DONE")
         sys.exit()
 
     def blit(self):


### PR DESCRIPTION
Switched over to threading from multiprocessing. Implemented some other tricks for slight performance increases. This fixes the hang-on-exit-due-to-child-processes issue. This closes #64 